### PR TITLE
fix: remove auto-newline behavior after tag selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Fuzzytag
 
+Forked and modified to change the behavior when a tag is selected.<br /><br />
+Now the cursor will be placed at the end of the tag instead of on the next line after `-`.<br /><br />
+
+---
+
 Based on the Frontmatter Tag Suggest plugin
 https://github.com/jmilldotdev/obsidian-frontmatter-tag-suggest
 
@@ -8,6 +13,6 @@ Thanks to the original plugin developer for the inspiration and base for creatin
 
 ![](screenshot.png)
 
-## Known issues:
+## Known issues
 
 Hacky implementation of highlighting in suggestions means that tags with special characters (`<` or `>`) might break. Feel free to submit a PR if this doesnt work with your workflow.

--- a/main.ts
+++ b/main.ts
@@ -139,15 +139,14 @@ class FuzzyTag extends EditorSuggest<string> {
 			}
 			if (this.inline) {
 				suggestion = `${suggestion},`;
-			} else {
-				suggestion = `${suggestion}\n-`;
 			}
 			(this.context.editor as Editor).replaceRange(
 				//This might break if you use special characters in your tags
-				`${suggestion.replace(/<\/?[^>]+(>|$)/g, "")} `,
+				`${suggestion.replace(/<\/?[^>]+(>|$)/g, "")}`,
 				this.context.start,
 				this.context.end
 			);
+			this.close();
 		}
 	}
 }


### PR DESCRIPTION
- Remove automatic newline with dash insertion after selecting a tag
- Remove trailing space after completed tag
- Add explicit modal close to properly dismiss suggestions
- Cursor now remains at end of selected tag for better UX

Fixes annoying workflow where selecting a tag would immediately start a new tag line, forcing users to manually clean up unwanted newlines and dashes.